### PR TITLE
Added wrapper around windows.h include to undefine WIN32_LEAN_AND_MEAN

### DIFF
--- a/sole.hpp
+++ b/sole.hpp
@@ -120,7 +120,13 @@ namespace std {
 #include <vector>
 
 #if defined(_WIN32)
-#   include <windows.h>
+#   ifdef WIN32_LEAN_AND_MEAN
+#       undef WIN32_LEAN_AND_MEAN
+#       include <windows.h>
+#       define WIN32_LEAN_AND_MEAN
+#   else
+#       include <windows.h>
+#   endif
 #   include <process.h>
 #   include <iphlpapi.h>
 #   pragma comment(lib,"iphlpapi.lib")


### PR DESCRIPTION
sole requires features that are stripped out with WIN32_LEAN_AND_MEAN.