### PR TITLE
Implements steady_clock for monotonicity within a process

### DIFF
--- a/sole.hpp
+++ b/sole.hpp
@@ -824,8 +824,12 @@ using namespace sole;
 
 namespace run
 {
+    auto basetime = std::chrono::system_clock::now();
+    auto basesteady = std::chrono::steady_clock::now();
     auto epoch = [](){
-        return std::chrono::system_clock::to_time_t( std::chrono::system_clock::now() );
+        return std::chrono::system_clock::to_time_t(
+          basetime + (std::chrono::steady_clock::now() - basesteady)
+        );
     };
 
     template<typename FN>
@@ -897,4 +901,3 @@ int main() {
 }
 
 #endif
-


### PR DESCRIPTION
This adds monotonicity to the timestamp generation function `epoch()` - limiting the chances of colliding UUIDs within processes. Particularly useful in scenarios where UUID0 is used heavily.